### PR TITLE
Add probot settings for declarative repo configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,36 @@
+repository:
+  default_branch: main
+  allow_rebase_merge: true
+  allow_squash_merge: false
+  allow_merge_commit: false
+  delete_branch_on_merge: true
+  has_projects: false
+  has_wiki: false
+  has_downloads: false
+  has_issues: true
+  allow_auto_merge: true
+  enable_vulnerability_alerts: true
+  enable_automated_security_fixes: true
+
+labels:
+  - name: bug
+    color: CC0000
+    description: Something isn't working
+  - name: enhancement
+    color: "336699"
+    description: New feature or request
+  - name: documentation
+    color: 0075ca
+    description: Improvements or additions to documentation
+  - name: question
+    color: d876e3
+    description: Further information is requested
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews: null
+      required_status_checks: null
+      enforce_admins: null
+      required_linear_history: true
+      restrictions: null

--- a/README.md
+++ b/README.md
@@ -31,19 +31,6 @@ The base config in `.github/settings.yml` enforces:
 - **Labels:** bug, enhancement, documentation, question
 - **Branch protection:** linear history required on `main`
 
-## Per-repo overrides
-
-Each file in `settings/` extends the base and adds repo-specific metadata (name, description, homepage, topics). Some repos deviate from the base:
-
-| Repo                       | Override                         |
-| -------------------------- | -------------------------------- |
-| `dotfiles`                 | private, has wiki, no auto-merge |
-| `notes`                    | private, no auto-merge           |
-| `obsidian-plugin-template` | template repo                    |
-| `obsidian-starter`         | template repo                    |
-| `philoserf`                | issues disabled                  |
-| `T01`                      | issues disabled                  |
-
 ## Common tasks
 
 **Regenerate per-repo configs** after changing repo metadata in GitHub:
@@ -58,8 +45,34 @@ fish scripts/generate.fish
 fish scripts/distribute.fish
 ```
 
-**Add a new repo:** Run `generate.fish` to pick it up automatically, then run `distribute.fish` to create its PR.
-
 **Change a shared setting:** Edit `.github/settings.yml`, commit, and push. All repos inheriting the base pick up the change on next Settings app sync.
 
 **Change a per-repo setting:** Edit the file in `settings/`, then copy it to that repo's `.github/settings.yml` (or re-run `distribute.fish`).
+
+## Adding a new repo
+
+1. Create the repo on GitHub (or confirm it already exists and is not archived).
+2. Install the [Settings app](https://github.com/apps/settings) on the new repo if it isn't already enabled for all repos.
+3. Regenerate configs — the script discovers all non-archived repos automatically:
+
+   ```bash
+   fish scripts/generate.fish
+   ```
+
+4. Review the generated file in `settings/<repo>.yml`. Add any overrides (e.g., `private: true`, `is_template: true`) if the repo deviates from the base.
+5. Commit the new config to this repo:
+
+   ```bash
+   git add settings/<repo>.yml
+   git commit -m "feat: add settings for <repo>"
+   ```
+
+6. Distribute the config to the new repo:
+
+   ```bash
+   fish scripts/distribute.fish
+   ```
+
+   The script skips repos that already have an open PR, so it's safe to run against all repos.
+
+7. Merge the PR in the new repo. The Settings app applies the config on merge.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# .github
+
+Declarative repository settings for all `philoserf` repos using [probot/settings](https://github.com/repository-settings/app).
+
+## How it works
+
+The Settings app reads `.github/settings.yml` from each repo on push to the default branch and applies the configuration via the GitHub API. Repos without their own config file inherit from this `.github` repo as a fallback.
+
+**Inheritance model:** Base config defines shared standards. Per-repo configs use `_extends: .github` to inherit the base and only specify metadata and overrides. Properties merge deeply — overriding one field won't lose the others.
+
+## Repo structure
+
+```
+.github/
+  settings.yml       Base config (merge strategy, labels, branch protection)
+settings/
+  <repo>.yml         Per-repo configs (19 files)
+scripts/
+  generate.fish      Pull current metadata from GH API, regenerate per-repo files
+  distribute.fish    Create PRs in each repo with their settings.yml
+```
+
+## Base config
+
+The base config in `.github/settings.yml` enforces:
+
+- **Merge strategy:** rebase only (no squash, no merge commits)
+- **Cleanup:** delete branches on merge, auto-merge enabled
+- **Security:** vulnerability alerts and automated fixes enabled
+- **Features:** issues enabled; wiki, projects, downloads disabled
+- **Labels:** bug, enhancement, documentation, question
+- **Branch protection:** linear history required on `main`
+
+## Per-repo overrides
+
+Each file in `settings/` extends the base and adds repo-specific metadata (name, description, homepage, topics). Some repos deviate from the base:
+
+| Repo                       | Override                         |
+| -------------------------- | -------------------------------- |
+| `dotfiles`                 | private, has wiki, no auto-merge |
+| `notes`                    | private, no auto-merge           |
+| `obsidian-plugin-template` | template repo                    |
+| `obsidian-starter`         | template repo                    |
+| `philoserf`                | issues disabled                  |
+| `T01`                      | issues disabled                  |
+
+## Common tasks
+
+**Regenerate per-repo configs** after changing repo metadata in GitHub:
+
+```bash
+fish scripts/generate.fish
+```
+
+**Distribute settings** to all repos (creates PRs):
+
+```bash
+fish scripts/distribute.fish
+```
+
+**Add a new repo:** Run `generate.fish` to pick it up automatically, then run `distribute.fish` to create its PR.
+
+**Change a shared setting:** Edit `.github/settings.yml`, commit, and push. All repos inheriting the base pick up the change on next Settings app sync.
+
+**Change a per-repo setting:** Edit the file in `settings/`, then copy it to that repo's `.github/settings.yml` (or re-run `distribute.fish`).

--- a/scripts/distribute.fish
+++ b/scripts/distribute.fish
@@ -1,0 +1,98 @@
+#!/usr/bin/env fish
+
+# Distribute settings.yml files to each repo via pull requests.
+# For each YAML file in settings/, clones the corresponding repo,
+# creates a branch, copies the config to .github/settings.yml,
+# commits, pushes, and opens a PR.
+
+set owner philoserf
+set settings_dir (status dirname)/../settings
+set branch feature/add-repo-settings
+set commit_msg "feat: add repository settings configuration"
+set pr_title "Add repository settings configuration"
+set pr_body "Add `.github/settings.yml` for declarative repo settings via [probot/settings](https://github.com/repository-settings/app).
+
+This config extends the base settings from \`philoserf/.github\` and includes repo-specific metadata and overrides.
+
+Settings are applied automatically when the Settings app is installed and this PR is merged."
+
+set tmpdir (mktemp -d)
+set -l succeeded 0
+set -l failed 0
+set -l skipped 0
+
+# Collect repo names from settings files
+set configs (find $settings_dir -name '*.yml' -type f)
+
+if test (count $configs) -eq 0
+    echo "No config files found in $settings_dir/" >&2
+    exit 1
+end
+
+echo "Will create PRs for "(count $configs)" repos."
+echo "Temp directory: $tmpdir"
+echo ""
+
+read -P "Continue? [y/N] " confirm
+if not string match -qi y $confirm
+    echo "Aborted."
+    rm -rf $tmpdir
+    exit 0
+end
+
+echo ""
+
+for config in $configs
+    set repo (basename $config .yml)
+    set repo_dir $tmpdir/$repo
+
+    echo "[$repo]"
+
+    # Check if PR already exists
+    set existing_pr (gh pr list --repo "$owner/$repo" --head $branch --json number --jq '.[0].number' 2>/dev/null)
+    if test -n "$existing_pr"
+        echo "  PR #$existing_pr already exists, skipping"
+        set skipped (math $skipped + 1)
+        continue
+    end
+
+    # Shallow clone
+    if not gh repo clone "$owner/$repo" $repo_dir -- --depth 1 2>/dev/null
+        echo "  Failed to clone, skipping" >&2
+        set failed (math $failed + 1)
+        continue
+    end
+
+    # Create branch, copy config, commit, push, PR
+    pushd $repo_dir
+
+    git checkout -b $branch 2>/dev/null
+
+    mkdir -p .github
+    cp $config .github/settings.yml
+
+    git add .github/settings.yml
+    git commit -m $commit_msg --quiet
+
+    if not git push -u origin $branch --quiet 2>/dev/null
+        echo "  Failed to push branch" >&2
+        set failed (math $failed + 1)
+        popd
+        continue
+    end
+
+    if gh pr create --title $pr_title --body $pr_body --head $branch 2>/dev/null
+        echo "  PR created"
+        set succeeded (math $succeeded + 1)
+    else
+        echo "  Failed to create PR" >&2
+        set failed (math $failed + 1)
+    end
+
+    popd
+end
+
+rm -rf $tmpdir
+
+echo ""
+echo "Done: $succeeded created, $skipped skipped, $failed failed"

--- a/scripts/generate.fish
+++ b/scripts/generate.fish
@@ -1,0 +1,104 @@
+#!/usr/bin/env fish
+
+# Generate per-repo settings.yml files from GitHub API data.
+# Pulls current metadata for each active philoserf repo and writes
+# a settings/ YAML file with _extends: .github plus repo-specific overrides.
+
+set owner philoserf
+set settings_dir (status dirname)/../settings
+set -l excluded .github
+
+# Repos with known deviations from the base config
+set -l private_repos notes dotfiles
+set -l no_auto_merge notes dotfiles
+set -l has_wiki dotfiles
+set -l no_issues philoserf T01
+set -l template_repos obsidian-plugin-template obsidian-starter
+
+mkdir -p $settings_dir
+
+echo "Fetching repos for $owner..."
+
+set repos (gh repo list $owner --no-archived --json name --jq '.[].name' --limit 100)
+
+if test $status -ne 0
+    echo "Failed to fetch repo list" >&2
+    exit 1
+end
+
+set count 0
+
+for repo in $repos
+    if contains -- $repo $excluded
+        continue
+    end
+
+    echo "  $repo"
+
+    set data (gh api "repos/$owner/$repo" --jq '[.name, .description // "", .homepage // "", (.topics // [] | join(", ")), .private, .is_template] | @tsv')
+
+    if test $status -ne 0
+        echo "    Failed to fetch metadata, skipping" >&2
+        continue
+    end
+
+    set fields (string split \t -- $data)
+    set name $fields[1]
+    set description $fields[2]
+    set homepage $fields[3]
+    set topics $fields[4]
+    set is_private $fields[5]
+    set is_template $fields[6]
+
+    set outfile $settings_dir/$name.yml
+
+    # Start building the YAML
+    set -l lines
+    set -a lines "_extends: .github"
+    set -a lines ""
+    set -a lines "repository:"
+    set -a lines "  name: $name"
+
+    if test -n "$description"
+        # Escape double quotes in description
+        set escaped_desc (string replace --all '"' '\\"' -- $description)
+        set -a lines "  description: \"$escaped_desc\""
+    end
+
+    if test -n "$homepage"
+        set -a lines "  homepage: $homepage"
+    end
+
+    if test -n "$topics"
+        set -a lines "  topics:"
+        for topic in (string split ", " -- $topics)
+            set -a lines "    - $topic"
+        end
+    end
+
+    if test "$is_private" = true
+        set -a lines "  private: true"
+    end
+
+    # Deviations from base
+    if contains -- $name $has_wiki
+        set -a lines "  has_wiki: true"
+    end
+
+    if contains -- $name $no_issues
+        set -a lines "  has_issues: false"
+    end
+
+    if contains -- $name $no_auto_merge
+        set -a lines "  allow_auto_merge: false"
+    end
+
+    if contains -- $name $template_repos; or test "$is_template" = true
+        set -a lines "  is_template: true"
+    end
+
+    printf '%s\n' $lines >$outfile
+    set count (math $count + 1)
+end
+
+echo "Generated $count repo configs in $settings_dir/"

--- a/settings/T01.yml
+++ b/settings/T01.yml
@@ -1,0 +1,7 @@
+_extends: .github
+
+repository:
+  name: T01
+  description: "This is an experiment. It is beginning now."
+  homepage: https://flowershow.app/@philoserf/T01
+  has_issues: false

--- a/settings/both.yml
+++ b/settings/both.yml
@@ -1,0 +1,6 @@
+_extends: .github
+
+repository:
+  name: both
+  description: "Placeholder "
+  homepage: https://my.flowershow.app/@philoserf/both

--- a/settings/claude-code-setup.yml
+++ b/settings/claude-code-setup.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: claude-code-setup
+  description: "Comprehensive Claude Code configuration with agents, skills, hooks, and automation"
+  homepage: https://philoserf.github.io/claude-code-setup/
+  topics:
+    - claude-code

--- a/settings/crbgc.yml
+++ b/settings/crbgc.yml
@@ -1,0 +1,6 @@
+_extends: .github
+
+repository:
+  name: crbgc
+  description: "a website for the Common & Recent Bogey Golf Club"
+  homepage: https://crbgc.org/

--- a/settings/dotfiles.yml
+++ b/settings/dotfiles.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: dotfiles
+  description: "private"
+  private: true
+  has_wiki: true
+  allow_auto_merge: false

--- a/settings/go.yml
+++ b/settings/go.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: go
+  description: "tools and libraries"
+  homepage: https://philoserf.github.io/go/
+  topics:
+    - go

--- a/settings/neocities.yml
+++ b/settings/neocities.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: neocities
+  description: "brochure ware"
+  homepage: https://philoserf.neocities.org
+  topics:
+    - personal-website

--- a/settings/notes.yml
+++ b/settings/notes.yml
@@ -1,0 +1,7 @@
+_extends: .github
+
+repository:
+  name: notes
+  description: "My private Obsidian vault"
+  private: true
+  allow_auto_merge: false

--- a/settings/obsidian-metadator.yml
+++ b/settings/obsidian-metadator.yml
@@ -1,0 +1,9 @@
+_extends: .github
+
+repository:
+  name: obsidian-metadator
+  description: "Automatically generate metadata for your Obsidian notes using Claude AI from Anthropic. It analyzes a note and generates tags, descriptions, and titles, customizable to your workflow."
+  homepage: https://philoserf.github.io/obsidian-metadator/
+  topics:
+    - metadata
+    - obsidian-plugin

--- a/settings/obsidian-plugin-template.yml
+++ b/settings/obsidian-plugin-template.yml
@@ -1,0 +1,7 @@
+_extends: .github
+
+repository:
+  name: obsidian-plugin-template
+  description: "Minimal template for Obsidian plugins using Bun"
+  homepage: https://philoserf.github.io/obsidian-plugin-template/
+  is_template: true

--- a/settings/obsidian-publisher.yml
+++ b/settings/obsidian-publisher.yml
@@ -1,0 +1,10 @@
+_extends: .github
+
+repository:
+  name: obsidian-publisher
+  description: "Publish Obsidian notes to GitHub for Hugo processing. This plugin converts Obsidian syntax (wikilinks, image references) to Hugo markdown and uploads files via the GitHub API."
+  homepage: https://philoserf.github.io/obsidian-publisher/
+  topics:
+    - github-pages
+    - hugo
+    - obsidian-plugin

--- a/settings/obsidian-starter.yml
+++ b/settings/obsidian-starter.yml
@@ -1,0 +1,10 @@
+_extends: .github
+
+repository:
+  name: obsidian-starter
+  description: "Start with nothing. Build what you need. Minimal Obsidian template."
+  homepage: https://philoserf.github.io/obsidian-starter/
+  topics:
+    - obsidian-md
+    - obsidian-vault
+  is_template: true

--- a/settings/obsidian-tools.yml
+++ b/settings/obsidian-tools.yml
@@ -1,0 +1,6 @@
+_extends: .github
+
+repository:
+  name: obsidian-tools
+  description: "A collection of tools for use with Obsidian"
+  homepage: https://philoserf.github.io/obsidian-tools/

--- a/settings/obsidian-vault-changelog.yml
+++ b/settings/obsidian-vault-changelog.yml
@@ -1,0 +1,9 @@
+_extends: .github
+
+repository:
+  name: obsidian-vault-changelog
+  description: "An Obsidian plugin to maintain a changelog of recently edited notes"
+  homepage: https://philoserf.github.io/obsidian-vault-changelog/
+  topics:
+    - changelog
+    - obsidian-plugin

--- a/settings/philoserf.github.io.yml
+++ b/settings/philoserf.github.io.yml
@@ -1,0 +1,6 @@
+_extends: .github
+
+repository:
+  name: philoserf.github.io
+  description: "A small page on a massive Internet"
+  homepage: https://philoserf.github.io/

--- a/settings/philoserf.yml
+++ b/settings/philoserf.yml
@@ -1,0 +1,9 @@
+_extends: .github
+
+repository:
+  name: philoserf
+  description: "A GitHub user account profile"
+  homepage: https://philoserf.github.io/philoserf/
+  topics:
+    - bio
+  has_issues: false

--- a/settings/sandbox.yml
+++ b/settings/sandbox.yml
@@ -1,0 +1,6 @@
+_extends: .github
+
+repository:
+  name: sandbox
+  description: "COGITA·DISCE·NECTE·ENVNTIA"
+  homepage: http://markpaulayers.com/

--- a/settings/site.yml
+++ b/settings/site.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: site
+  description: "My personal website"
+  homepage: https://philoserf.com/
+  topics:
+    - personal-website

--- a/settings/tmp.yml
+++ b/settings/tmp.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: tmp
+  description: "a test Hugo site"
+  homepage: https://philoserf.github.io/tmp/
+  topics:
+    - test-site


### PR DESCRIPTION
## Summary

- Add base `settings.yml` with shared standards (rebase-only merge, labels, branch protection)
- Generate per-repo configs for all 19 active repos with `_extends: .github` inheritance
- Add `generate.fish` script to pull metadata from GitHub API
- Add `distribute.fish` script to create PRs in target repos

## Context

Manages all `philoserf` GitHub repo settings declaratively using [repository-settings/app](https://github.com/repository-settings/app). The base config in `.github/settings.yml` defines standards; per-repo files in `settings/` override only what differs.

## Test plan

- [x] Install [Settings app](https://github.com/apps/settings) on all repos
- [x] Merge this PR so base config is available
- [x] Pilot: run `distribute.fish` on one low-risk repo (e.g., `sandbox`), verify settings applied
- [x] Roll out: run `distribute.fish` for remaining repos
- [x] Spot-check labels, merge strategy, and branch protection on 3-4 repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)