### PR TITLE
chore: sync repo configs with GitHub state

### DIFF
--- a/settings/cc-plugins.yml
+++ b/settings/cc-plugins.yml
@@ -1,0 +1,10 @@
+_extends: .github
+
+repository:
+  name: cc-plugins
+  description: "Claude Code plugins by Mark Ayers"
+  homepage: false
+  topics:
+    - claude-code-plugin
+  has_wiki: true
+  has_issues: 

--- a/settings/contacts-cli.yml
+++ b/settings/contacts-cli.yml
@@ -1,8 +1,0 @@
-_extends: .github
-
-repository:
-  name: contacts-cli
-  description: "A Swift CLI for managing contacts"
-  topics:
-    - cli
-    - swift

--- a/settings/cx.yml
+++ b/settings/cx.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: cx
+  description: "macOS CLI for managing Apple Contacts via JXA"
+  homepage: false
+  has_wiki: true
+  has_issues: 

--- a/settings/dotfiles.archive.too.yml
+++ b/settings/dotfiles.archive.too.yml
@@ -1,7 +1,0 @@
-_extends: .github
-
-repository:
-  name: dotfiles.archive.too
-  description: "ARCHIVE: Home directory dotfiles managed with yadm"
-  topics:
-    - dotfiles

--- a/settings/dotfiles.archive.yml
+++ b/settings/dotfiles.archive.yml
@@ -1,7 +1,0 @@
-_extends: .github
-
-repository:
-  name: dotfiles.archive
-  description: "ARCHIVE: Another yadm-managed personal dotfile collection"
-  topics:
-    - dotfiles

--- a/settings/obsidian-calendar.yml
+++ b/settings/obsidian-calendar.yml
@@ -1,7 +1,0 @@
-_extends: .github
-
-repository:
-  name: obsidian-calendar
-  description: "ARCHIVE: Simple calendar widget for Obsidian"
-  topics:
-    - obsidian-plugin

--- a/settings/obsidian-nldates.yml
+++ b/settings/obsidian-nldates.yml
@@ -1,7 +1,0 @@
-_extends: .github
-
-repository:
-  name: obsidian-nldates
-  description: "ARCHIVE: Work with dates in natural language in Obsidian"
-  topics:
-    - obsidian-plugin

--- a/settings/obsidian-review.yml
+++ b/settings/obsidian-review.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: obsidian-review
+  description: "An Obsidian plugin to randomly review your vault notes and track progress."
+  homepage: false
+  has_wiki: true
+  has_issues: 

--- a/settings/obsidian-vault-review.yml
+++ b/settings/obsidian-vault-review.yml
@@ -1,7 +1,0 @@
-_extends: .github
-
-repository:
-  name: obsidian-vault-review
-  description: "This plugin allows you to create a snapshot of your vault and randomly review files from it 1-by-1."
-  topics:
-    - obsidian-plugin


### PR DESCRIPTION
## Summary

- Add configs for new repos: `cc-plugins`, `cx`, `obsidian-review`
- Remove stale configs:
  - Deleted repos: `contacts-cli`, `dotfiles.archive`, `dotfiles.archive.too`
  - Archived repos: `obsidian-calendar`, `obsidian-nldates`
  - Renamed → `obsidian-review`: `obsidian-vault-review`

Brings `settings/` in line with the current non-archived repo list on GitHub.